### PR TITLE
feat(entity-linker): --ner-fallback フラグで about_entities 空 Fact に NER 自動補完

### DIFF
--- a/.claude/skills/save-to-research-graph/SKILL.md
+++ b/.claude/skills/save-to-research-graph/SKILL.md
@@ -79,7 +79,8 @@ uv run python scripts/emit_research_queue.py \
 ```bash
 uv run python scripts/entity_linker.py \
   --input {graph_queue_file} \
-  --instance research
+  --instance research \
+  --ner-fallback
 ```
 
 出力先: `.tmp/graph-queue/{command}/linked-{timestamp}.json`

--- a/scripts/entity_linker.py
+++ b/scripts/entity_linker.py
@@ -66,6 +66,7 @@ import argparse
 import functools
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -78,6 +79,11 @@ from urllib.parse import urlparse, urlunparse
 import yaml
 from neo4j import GraphDatabase
 from neo4j.exceptions import ClientError
+
+try:
+    import anthropic  # type: ignore[import-untyped]
+except ImportError:
+    anthropic = None  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Logger
@@ -1236,6 +1242,150 @@ def _compute_stats(items: list[dict[str, Any]]) -> dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
+# NER Fallback: Fill about_entities for empty Fact/Claim
+# ---------------------------------------------------------------------------
+
+_NER_SYSTEM_PROMPT = (
+    "Extract named entities (companies, organizations, people, assets, markets, "
+    "products, economic indicators, countries) from each text. "
+    'Return JSON: {"0": ["entity1", "entity2"], "1": [...], ...}'
+)
+
+_NER_TIMEOUT_SECONDS = 30
+
+
+def _collect_empty_about_entity_items(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return Fact/Claim dicts where ``about_entities`` is an empty list.
+
+    Items where ``about_entities`` key is absent are excluded.
+    Items where ``about_entities`` is non-empty are excluded.
+    """
+    targets: list[dict[str, Any]] = []
+    for source in data.get("sources", []):
+        for chunk in source.get("chunks", []):
+            for item in chunk.get("facts", []) + chunk.get("claims", []):
+                if "about_entities" in item and item["about_entities"] == []:
+                    targets.append(item)
+    return targets
+
+
+def _ner_call_batch(
+    client: Any,
+    batch: list[dict[str, Any]],
+    batch_idx: int,
+    n_batches: int,
+) -> dict[str, list[str]] | None:
+    """Call Anthropic NER API for a single batch.
+
+    Returns parsed JSON dict on success, None on any error (silent skip).
+    """
+    contents = [item.get("content", "") for item in batch]
+    text_block = "\n".join(f"{i}: {c}" for i, c in enumerate(contents))
+    user_message = f"Texts:\n{text_block}"
+    try:
+        response = client.messages.create(
+            model="claude-haiku-4-5",
+            max_tokens=512,
+            timeout=_NER_TIMEOUT_SECONDS,
+            system=_NER_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_message}],
+        )
+        return json.loads(response.content[0].text)  # type: ignore[no-any-return]
+    except Exception as exc:
+        logger.warning(
+            "_ner_fill_about_entities: batch %d/%d failed, skipping — %s",
+            batch_idx + 1,
+            n_batches,
+            exc,
+        )
+        return None
+
+
+def _apply_ner_results(
+    batch: list[dict[str, Any]],
+    ner_result: dict[str, list[str]],
+    data: dict[str, Any],
+    existing_names: set[str],
+) -> None:
+    """Write NER results back into batch items and update ``data["entities"]``."""
+    for i, item in enumerate(batch):
+        entity_names: list[str] = ner_result.get(str(i), [])
+        if not entity_names:
+            continue
+        item["about_entities"] = entity_names
+        for name in entity_names:
+            if name not in existing_names:
+                existing_names.add(name)
+                data.setdefault("entities", []).append({"name": name})
+
+
+def _ner_fill_about_entities(
+    data: dict[str, Any],
+    batch_size: int = 20,
+) -> dict[str, Any]:
+    """Fill ``about_entities`` for empty Fact/Claim items using Haiku NER.
+
+    Scans ``sources[].chunks[].facts[]`` and ``claims[]`` for items where
+    ``about_entities`` is an empty list, calls Anthropic claude-haiku-4-5 in
+    batches to extract named entities, and writes the results back.
+
+    Extracted entity names are also appended to ``data["entities"]``
+    (deduplicating by name).
+
+    Parameters
+    ----------
+    data
+        Graph-queue JSON dict (mutated in-place for ``about_entities``).
+    batch_size
+        Maximum number of items per Anthropic API call.
+
+    Returns
+    -------
+    dict
+        The same ``data`` dict, with ``about_entities`` and ``entities``
+        updated.
+
+    Notes
+    -----
+    * API errors are silently skipped so the pipeline is never blocked.
+    * Items where ``about_entities`` key is absent are left untouched.
+    * Items where ``about_entities`` is non-empty are skipped.
+    """
+    if anthropic is None:
+        logger.warning("anthropic package not installed, skipping --ner-fallback")
+        return data
+
+    targets = _collect_empty_about_entity_items(data)
+    if not targets:
+        logger.debug("_ner_fill_about_entities: no empty about_entities found, skipping")
+        return data
+
+    logger.info(
+        "_ner_fill_about_entities: %d items to process (batch_size=%d)",
+        len(targets),
+        batch_size,
+    )
+
+    existing_names: set[str] = {e["name"] for e in data.get("entities", []) if "name" in e}
+    client = anthropic.Anthropic()
+    n_batches = math.ceil(len(targets) / batch_size)
+
+    for batch_idx in range(n_batches):
+        batch = targets[batch_idx * batch_size : (batch_idx + 1) * batch_size]
+        ner_result = _ner_call_batch(client, batch, batch_idx, n_batches)
+        if ner_result is not None:
+            _apply_ner_results(batch, ner_result, data, existing_names)
+            logger.debug(
+                "_ner_fill_about_entities: batch %d/%d done",
+                batch_idx + 1,
+                n_batches,
+            )
+
+    logger.info("_ner_fill_about_entities: completed for %d items", len(targets))
+    return data
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -1287,6 +1437,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to entity-linker-config.yaml (default: auto-detect)",
     )
+    parser.add_argument(
+        "--ner-fallback",
+        action="store_true",
+        help="Run Haiku NER on Fact/Claim items where about_entities is empty "
+        "and set the extracted entities before the normal resolve flow. "
+        "Requires the 'anthropic' package. API errors are silently skipped.",
+    )
     return parser
 
 
@@ -1326,6 +1483,11 @@ def main() -> None:
     logger.info(
         "Connecting to %s (instance: %s)", _mask_uri(config["bolt_uri"]), args.instance
     )
+
+    # --ner-fallback: fill about_entities for empty Fact/Claim before linking
+    if args.ner_fallback:
+        logger.info("--ner-fallback enabled: running NER pre-fill on empty about_entities")
+        data = _ner_fill_about_entities(data)
 
     client = Neo4jClient(
         uri=config["bolt_uri"],

--- a/tests/scripts/test_entity_linker_ner.py
+++ b/tests/scripts/test_entity_linker_ner.py
@@ -1,0 +1,361 @@
+"""Tests for entity_linker._ner_fill_about_entities.
+
+--ner-fallback フラグで about_entities 空の Fact/Claim に
+NER 自動補完される機能のユニットテスト。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_data(
+    *,
+    facts: list[dict[str, Any]] | None = None,
+    claims: list[dict[str, Any]] | None = None,
+    entities: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build minimal graph-queue data for testing."""
+    chunk: dict[str, Any] = {}
+    if facts is not None:
+        chunk["facts"] = facts
+    if claims is not None:
+        chunk["claims"] = claims
+    return {
+        "entities": entities or [],
+        "sources": [
+            {
+                "chunks": [chunk],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _ner_fill_about_entities tests
+# ---------------------------------------------------------------------------
+
+
+class TestNerFillAboutEntities:
+    """_ner_fill_about_entities のユニットテスト。"""
+
+    def test_正常系_about_entities空のfactにentityが補完される(self) -> None:
+        """about_entities が空の Fact に対して NER 結果が補完されること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Apple reported record revenue.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"0": ["Apple"]}')]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            result = _ner_fill_about_entities(data)
+
+        fact = result["sources"][0]["chunks"][0]["facts"][0]
+        assert "Apple" in fact["about_entities"]
+
+    def test_正常系_about_entities空のclaimにentityが補完される(self) -> None:
+        """about_entities が空の Claim に対して NER 結果が補完されること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            claims=[
+                {"content": "Microsoft Azure grows 30%.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"0": ["Microsoft", "Azure"]}')]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            result = _ner_fill_about_entities(data)
+
+        claim = result["sources"][0]["chunks"][0]["claims"][0]
+        assert "Microsoft" in claim["about_entities"]
+        assert "Azure" in claim["about_entities"]
+
+    def test_正常系_data_entitiesに重複なく追加される(self) -> None:
+        """抽出した entity 名が data['entities'] に重複なく追加されること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Google dominates search.", "about_entities": []},
+                {"content": "Google Cloud grows.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        mock_response = MagicMock()
+        # Both facts contain "Google"
+        mock_response.content = [
+            MagicMock(text='{"0": ["Google"], "1": ["Google", "Google Cloud"]}')
+        ]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            result = _ner_fill_about_entities(data)
+
+        entity_names = [e["name"] for e in result["entities"]]
+        # "Google" should appear exactly once despite two facts
+        assert entity_names.count("Google") == 1
+
+    def test_正常系_about_entities非空のfactはスキップされる(self) -> None:
+        """about_entities が既に設定されている Fact は NER 対象外であること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {
+                    "content": "Already annotated fact.",
+                    "about_entities": ["ExistingEntity"],
+                },
+                {"content": "Empty fact.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        mock_response = MagicMock()
+        # Only index 0 (the empty fact) is sent — mapped as index "0"
+        mock_response.content = [MagicMock(text='{"0": ["NewEntity"]}')]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            result = _ner_fill_about_entities(data)
+
+        chunks = result["sources"][0]["chunks"][0]
+        # Annotated fact unchanged
+        assert chunks["facts"][0]["about_entities"] == ["ExistingEntity"]
+        # Empty fact gets NER result
+        assert "NewEntity" in chunks["facts"][1]["about_entities"]
+
+    def test_正常系_about_entitiesキーなしのfactはスキップされる(self) -> None:
+        """about_entities キー自体がない Fact は NER 対象外であること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Fact without about_entities key."},
+            ],
+            entities=[],
+        )
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+
+            result = _ner_fill_about_entities(data)
+
+        # No API call should be made (no empty about_entities to process)
+        mock_client.messages.create.assert_not_called()
+        assert (
+            result["sources"][0]["chunks"][0]["facts"][0].get("about_entities") is None
+        )
+
+    def test_異常系_APIエラー時にサイレントスキップされる(self) -> None:
+        """Anthropic API エラー時にも例外を発生させず投入が継続されること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Some important fact.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.side_effect = Exception("API timeout")
+
+            # Must not raise
+            result = _ner_fill_about_entities(data)
+
+        # about_entities remains empty (silently skipped)
+        fact = result["sources"][0]["chunks"][0]["facts"][0]
+        assert fact["about_entities"] == []
+
+    def test_異常系_NER結果が空の場合は何もしない(self) -> None:
+        """NER 結果が空のレスポンスの場合は about_entities を変更しないこと。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Abstract content with no entities.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"0": []}')]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            result = _ner_fill_about_entities(data)
+
+        fact = result["sources"][0]["chunks"][0]["facts"][0]
+        assert fact["about_entities"] == []
+
+    def test_正常系_データが空の場合はAPIを呼ばない(self) -> None:
+        """sources/chunks/facts が全てない場合は API 呼び出しが行われないこと。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data: dict[str, Any] = {"entities": [], "sources": []}
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+
+            result = _ner_fill_about_entities(data)
+
+        mock_client.messages.create.assert_not_called()
+        assert result["entities"] == []
+
+    def test_正常系_バッチサイズ超過時に複数バッチで処理される(self) -> None:
+        """batch_size を超える件数が複数バッチで処理されること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        # Create 3 facts with empty about_entities, batch_size=2
+        facts = [
+            {"content": f"Fact about Company{i}.", "about_entities": []}
+            for i in range(3)
+        ]
+        data = _make_data(facts=facts, entities=[])
+
+        call_count = 0
+
+        def mock_create(**kwargs: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            # Return one entity per item in the batch
+            texts = kwargs.get("messages", [{}])[0].get("content", "")
+            # Count lines that start with digit (0:, 1:)
+            items_in_batch = sum(
+                1 for line in texts.split("\n") if line and line[0].isdigit()
+            )
+            payload = {
+                str(i): [f"CompanyBatch{call_count}_{i}"] for i in range(items_in_batch)
+            }
+            import json
+
+            mock_resp.content = [MagicMock(text=json.dumps(payload))]
+            return mock_resp
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.side_effect = mock_create
+
+            _ner_fill_about_entities(data, batch_size=2)
+
+        # 3 items with batch_size=2 → ceil(3/2) = 2 API calls
+        assert call_count == 2
+
+    def test_正常系_既存entitiesに重複しない名前のみ追加される(self) -> None:
+        """data['entities'] に既に存在する名前は重複して追加されないこと。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Apple is a tech company.", "about_entities": []},
+            ],
+            entities=[{"name": "Apple", "entity_type": "company"}],
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"0": ["Apple", "Google"]}')]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            result = _ner_fill_about_entities(data)
+
+        entity_names = [e["name"] for e in result["entities"]]
+        # Apple already existed, should not be duplicated
+        assert entity_names.count("Apple") == 1
+        # Google is new, should be added
+        assert "Google" in entity_names
+
+    def test_異常系_不正なJSONレスポンス時にサイレントスキップされる(self) -> None:
+        """API が不正な JSON を返した場合もサイレントスキップされること。"""
+        from entity_linker import _ner_fill_about_entities
+
+        data = _make_data(
+            facts=[
+                {"content": "Some fact.", "about_entities": []},
+            ],
+            entities=[],
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="not valid json!!!")]
+
+        with patch("entity_linker.anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.Anthropic.return_value = mock_client
+            mock_client.messages.create.return_value = mock_response
+
+            # Must not raise
+            result = _ner_fill_about_entities(data)
+
+        # about_entities should remain untouched
+        fact = result["sources"][0]["chunks"][0]["facts"][0]
+        assert fact["about_entities"] == []
+
+
+# ---------------------------------------------------------------------------
+# --ner-fallback CLI flag tests
+# ---------------------------------------------------------------------------
+
+
+class TestNerFallbackCliFlag:
+    """--ner-fallback CLI フラグのテスト。"""
+
+    def test_正常系_ner_fallbackフラグが解析される(self) -> None:
+        """--ner-fallback フラグが argparse で認識されること。"""
+        from entity_linker import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["--input", "test.json", "--instance", "research", "--ner-fallback"]
+        )
+        assert args.ner_fallback is True
+
+    def test_正常系_ner_fallbackデフォルトはFalse(self) -> None:
+        """--ner-fallback を指定しない場合はデフォルト False であること。"""
+        from entity_linker import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["--input", "test.json", "--instance", "research"])
+        assert args.ner_fallback is False


### PR DESCRIPTION
## 概要

- `entity_linker.py` に `--ner-fallback` フラグを追加し、`about_entities` が空の Fact/Claim に対して Haiku で NER を実行して自動補完する
- RELATES_TO 欠落防止機構として 537件の孤立 Fact 再発を防止する
- `save-to-research-graph` スキルの標準呼び出しに `--ner-fallback` を追加

## 変更ファイル

- `scripts/entity_linker.py`: `--ner-fallback` フラグ + `_ner_fill_about_entities()` 実装（ヘルパー3関数に分割してブランチ数を制御）
- `tests/scripts/test_entity_linker_ner.py`: ユニットテスト13件（新規）
- `.claude/skills/save-to-research-graph/SKILL.md`: `--ner-fallback` を標準引数に追加

## 受け入れ条件の確認

- [x] `--ner-fallback` フラグなしでは既存動作が変わらない
- [x] `--ner-fallback` 指定時、about_entities 空の Fact に entity が補完される
- [x] API エラー時でも投入が継続される（サイレントスキップ）
- [x] `uv run make test` が通る（13件追加、既存81件も全パス）
- [x] save-to-research-graph スキルに --ner-fallback が追加されている

## テストプラン

- [x] `uv run pytest tests/scripts/test_entity_linker_ner.py -v` — 13件全てパス
- [x] `uv run pytest tests/scripts/test_entity_linker.py -v` — 68件全てパス（既存テスト回帰なし）

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)